### PR TITLE
Add Columns to Store Tests Macro

### DIFF
--- a/dbt/macros/test_analytics/store_test_results.sql
+++ b/dbt/macros/test_analytics/store_test_results.sql
@@ -1,13 +1,8 @@
+/*
+  --add "{{ store_test_results(results) }}" to an on-run-end: block in dbt_project.yml 
+  --run with dbt build --store-failures. The next v.1.0.X release of dbt will include post run hooks for dbt test! 
+*/
 {% macro store_test_results(results) %}
-  {# --add "{{ store_test_results(results) }}" to an on-run-end: block in dbt_project.yml #}
-  {# --run with dbt build --store-failures. The next v.1.0.X release of dbt will include post run hooks for dbt test! #}
-  {%- set test_results = [] -%}
-
-  {%- for result in results -%}
-    {%- if result.node.resource_type == 'test' -%}
-      {%- do test_results.append(result) -%}
-    {%- endif -%}
-  {%- endfor -%}
 
   {%- set central_tbl -%} {{ target.schema }}.test_results_central {%- endset -%}
   {%- set history_tbl -%} {{ target.schema }}.test_results_history {%- endset -%}
@@ -16,14 +11,29 @@
 
   create or replace table {{ central_tbl }} as (
   
-  {% for result in test_results %}
+  {% for result in results if result.node.resource_type == 'test' %}
+
+    {% set test_name='' %}
+    {% set test_type='' %}
+
+    {% if result.node.test_metadata is defined %}
+      {% set test_name = result.node.test_metadata.name %}
+      {% set test_type='generic' %}
+    {% elif result.node.name is defined %}
+      {% set test_name = result.node.name %}
+      {% set test_type='singular' %}
+    {% endif %}
     
     select
-      '{{ result.node.name }}' as test_name,
-      '{{ result.node.unique_id }}' as model_name,
-      '{{ result.node.config.severity }}' as test_severity_config,
-      '{{ result.execution_time }}' as execution_time_seconds,
-      '{{ result.status }}' as test_result,
+      '{{ test_name }}'::text as test_name,
+      '{{ result.node.name }}'::text as test_name_long,
+      '{{ test_type}}'::text as test_type,
+      '{{ process_refs(result.node.refs) }}'::text as model_refs,
+      '{{ process_refs(result.node.sources, is_src=true) }}'::text as source_refs,
+      '{{ result.node.config.severity }}'::text as test_severity_config,
+      '{{ result.execution_time }}'::text as execution_time_seconds,
+      '{{ result.status }}'::text as test_result,
+      '{{ result.node.original_file_path }}'::text as file_test_defined,
       current_timestamp as _timestamp
     
     {{ "union all" if not loop.last }}
@@ -49,4 +59,31 @@
     ;
   {% endif %}
 
+{% endmacro %}
+
+
+/*
+  return a comma delimited string of the models or sources were related to the test.
+    e.g. dim_customers,fct_orders
+
+  behaviour changes slightly with the is_src flag because:
+    - models come through as [['model'], ['model_b']]
+    - srcs come through as [['source','table'], ['source_b','table_b']]
+*/
+{% macro process_refs( ref_list, is_src=false ) %}
+  {% set refs = [] %}
+
+  {% if ref_list is defined and ref_list|length > 0 %}
+      {% for ref in ref_list %}
+        {% if is_src %}
+          {{ refs.append(ref|join('.')) }}
+        {% else %}
+          {{ refs.append(ref[0]) }}
+        {% endif %} 
+      {% endfor %}
+
+      {{ return(refs|join(',')) }}
+  {% else %}
+      {{ return('') }}
+  {% endif %}
 {% endmacro %}


### PR DESCRIPTION
### This PR includes:
- Added additional test metadata columns to show name of test, models and sources tested, type of test, and file which triggered the test.
- Set data types for columns to deal with a truncation error

![image](https://user-images.githubusercontent.com/79948589/170913338-8b1982cf-3c63-4496-b073-ebe835bc4ad7.png)


